### PR TITLE
If CKAN login is not enable, then use SAML

### DIFF
--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -130,9 +130,8 @@ def disable_default_login_register():
 
 
 saml2auth.add_url_rule(u'/acs', view_func=acs, methods=[u'GET', u'POST'])
-saml2auth.add_url_rule(u'/user/saml2login', view_func=saml2login)
+
 if not h.is_default_login_enabled():
-    saml2auth.add_url_rule(
-        u'/user/login', view_func=disable_default_login_register)
+    saml2auth.add_url_rule(u'/user/login', view_func=saml2login)
     saml2auth.add_url_rule(
         u'/user/register', view_func=disable_default_login_register)

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -135,3 +135,5 @@ if not h.is_default_login_enabled():
     saml2auth.add_url_rule(u'/user/login', view_func=saml2login)
     saml2auth.add_url_rule(
         u'/user/register', view_func=disable_default_login_register)
+else:
+    saml2auth.add_url_rule(u'/user/saml2login', view_func=saml2login)


### PR DESCRIPTION
This PR avoid using a new URL to login with and external entity