### PR TITLE
name_id_policy_format is a string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,10 @@ Optional::
      # Default: urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
      ckanext.saml2auth.sp.name_id_format = urn:oasis:names:tc:SAML:2.0:nameid-format:persistent urn:oasis:names:tc:SAML:2.0:nameid-format:transient
 
+     # A string value that will be used to set the Format attribute of the <NameIDPolicy> element of the metadata of an entity.
+     # Default: <Not set>
+     ckanext.saml2auth.sp.name_id_policy_format = urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+
     # Entity ID (also know as Issuer)
     # Define the entity ID. Default is urn:mace:umu.se:saml:ckan:sp 
     ckanext.saml2auth.entity_id = urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:catalog-dev

--- a/ckanext/saml2auth/spconfig.py
+++ b/ckanext/saml2auth/spconfig.py
@@ -17,6 +17,8 @@ def get_config():
     name_id_format = \
         aslist(ckan_config.get(u'ckanext.saml2auth.sp.name_id_format',
                                "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"))
+    name_id_policy_format = ckan_config.get(u'ckanext.saml2auth.sp.name_id_policy_format')
+
     location = \
         ckan_config.get(u'ckanext.saml2auth.idp_metadata.location')
     local_path = \
@@ -48,7 +50,6 @@ def get_config():
                     u'assertion_consumer_service': [base + acs_endpoint]
                 },
                 u'allow_unsolicited': True,
-                u'name_id_policy_format': name_id_format[0],
                 u'name_id_format': name_id_format,
                 u'want_response_signed': response_signed,
                 u'want_assertions_signed': assertion_signed,
@@ -59,6 +60,9 @@ def get_config():
         u'debug': 1 if debug else 0,
         u'name_form': NAME_FORMAT_URI
         }
+
+    if name_id_policy_format:
+        config[u'service'][u'sp'][u'name_id_policy_format'] = name_id_policy_format
 
     if key_file is not None and cert_file is not None:
         config[u'key_file'] = key_file

--- a/ckanext/saml2auth/spconfig.py
+++ b/ckanext/saml2auth/spconfig.py
@@ -47,7 +47,7 @@ def get_config():
                     u'assertion_consumer_service': [base + u'/acs']
                 },
                 u'allow_unsolicited': True,
-                u'name_id_policy_format': name_id_format,
+                u'name_id_policy_format': name_id_format[0],
                 u'name_id_format': name_id_format,
                 u'want_response_signed': response_signed,
                 u'want_assertions_signed': assertion_signed,

--- a/ckanext/saml2auth/tests/test_spconfig.py
+++ b/ckanext/saml2auth/tests/test_spconfig.py
@@ -59,7 +59,7 @@ def test_paths():
 def test_name_id_policy_format_is_a_string():
 
     name_id_policy_format = get_config()[u'service'][u'sp'][u'name_id_policy_format']
-    assert name_id_policy_format  == NAME_ID_FORMAT.split(' ')[0]
+    assert name_id_policy_format == NAME_ID_FORMAT.split(' ')[0]
 
 
 @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'some:entity_id')

--- a/ckanext/saml2auth/tests/test_spconfig.py
+++ b/ckanext/saml2auth/tests/test_spconfig.py
@@ -3,6 +3,8 @@ import pytest
 
 from ckanext.saml2auth.spconfig import get_config
 
+NAME_ID_FORMAT = u'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+
 
 @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
 @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path', '/path/to/idp.xml')
@@ -51,6 +53,13 @@ def test_paths():
     assert cfg[u'cert_file'] == u'/path/to/mycert.pem'
     assert cfg[u'encryption_keypairs'] == [{u'key_file': '/path/to/mykey.pem', u'cert_file': '/path/to/mycert.pem'}]
     assert cfg[u'attribute_map_dir'] == '/path/to/attribute_map_dir'
+
+
+@pytest.mark.ckan_config(u'ckanext.saml2auth.name_id_format', NAME_ID_FORMAT)
+def test_name_id_policy_format_is_a_string():
+
+    name_id_policy_format = get_config()[u'service'][u'sp'][u'name_id_policy_format']
+    assert name_id_policy_format  == NAME_ID_FORMAT.split(' ')[0]
 
 
 @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'some:entity_id')

--- a/ckanext/saml2auth/tests/test_spconfig.py
+++ b/ckanext/saml2auth/tests/test_spconfig.py
@@ -3,8 +3,6 @@ import pytest
 
 from ckanext.saml2auth.spconfig import get_config
 
-NAME_ID_FORMAT = u'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
-
 
 @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
 @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path', '/path/to/idp.xml')
@@ -55,11 +53,15 @@ def test_paths():
     assert cfg[u'attribute_map_dir'] == '/path/to/attribute_map_dir'
 
 
-@pytest.mark.ckan_config(u'ckanext.saml2auth.name_id_format', NAME_ID_FORMAT)
-def test_name_id_policy_format_is_a_string():
+def test_name_id_policy_format_default_not_set():
+    assert 'name_id_policy_format' not in get_config()[u'service'][u'sp']
+
+
+@pytest.mark.ckan_config(u'ckanext.saml2auth.sp.name_id_policy_format', 'some_policy_format')
+def test_name_id_policy_format_set_in_config():
 
     name_id_policy_format = get_config()[u'service'][u'sp'][u'name_id_policy_format']
-    assert name_id_policy_format == NAME_ID_FORMAT.split(' ')[0]
+    assert name_id_policy_format == 'some_policy_format'
 
 
 @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'some:entity_id')


### PR DESCRIPTION
As stated in the docs:

https://pysaml2.readthedocs.io/en/latest/howto/config.html#name-id-policy-format

But here it was assigned the `name_id_format` variable, which is a list, causing an exception.

I'm not sure if it's worth having a separate config option for `name_id_policy_format` rather than reusing `name_id_format` but if so let me know.