### PR TITLE
Backport Make the ACS endpoint configurable to CKAN 2.8 branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,10 @@ Required::
 
 Optional::
 
+     # URL route of the endpoint where the SAML assertion is sent, also known as Assertion Consumer Service (ACS).
+     # Default: /acs
+     ckanext.saml2auth.acs_endpoint = /sso/post
+
      # Configuration setting that enables CKAN's internal register/login functionality as well
      # Default: False
      ckanext.saml2auth.enable_ckan_internal_login = True

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -38,6 +38,10 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
             if not config.get(option, None):
                 raise RuntimeError(missing_config.format(option))
 
+        acs_endpoint = config.get('ckanext.saml2auth.acs_endpoint')
+        if acs_endpoint and not acs_endpoint.startswith('/'):
+            raise RuntimeError('ckanext.saml2auth.acs_endpoint should start with a slash ("/")')
+
     # IBlueprint
 
     def get_blueprint(self):

--- a/ckanext/saml2auth/spconfig.py
+++ b/ckanext/saml2auth/spconfig.py
@@ -38,6 +38,7 @@ def get_config():
     key_file = ckan_config.get(u'ckanext.saml2auth.key_file_path', None)
     cert_file = ckan_config.get(u'ckanext.saml2auth.cert_file_path', None)
     attribute_map_dir = ckan_config.get(u'ckanext.saml2auth.attribute_map_dir', None)
+    acs_endpoint = ckan_config.get('ckanext.saml2auth.acs_endpoint', '/acs')
 
     config = {
         u'entityid': entity_id,
@@ -48,7 +49,7 @@ def get_config():
             u'sp': {
                 u'name': u'CKAN SP',
                 u'endpoints': {
-                    u'assertion_consumer_service': [base + u'/acs']
+                    u'assertion_consumer_service': [base + acs_endpoint]
                 },
                 u'allow_unsolicited': True,
                 u'name_id_policy_format': name_id_format,

--- a/ckanext/saml2auth/tests/test_spconfig.py
+++ b/ckanext/saml2auth/tests/test_spconfig.py
@@ -59,3 +59,10 @@ def test_read_entity_id():
 
     entity_id = get_config()[u'entityid']
     assert entity_id == u'some:entity_id'
+
+
+@helpers.change_config(u'ckanext.saml2auth.acs_endpoint', u'/my/acs/endpoint')
+def test_read_acs_endpoint():
+
+    acs_endpoint = get_config()[u'service'][u'sp'][u'endpoints'][u'assertion_consumer_service'][0]
+    assert acs_endpoint.endswith('/my/acs/endpoint')

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -129,7 +129,8 @@ def disable_default_login_register():
     return base.render(u'error_document_template.html', extra_vars), 403
 
 
-saml2auth.add_url_rule(u'/acs', view_func=acs, methods=[u'GET', u'POST'])
+acs_endpoint = config.get('ckanext.saml2auth.acs_endpoint', '/acs')
+saml2auth.add_url_rule(acs_endpoint, view_func=acs, methods=[u'GET', u'POST'])
 saml2auth.add_url_rule(u'/user/saml2login', view_func=saml2login)
 if not h.is_default_login_enabled():
     saml2auth.add_url_rule(


### PR DESCRIPTION
Back-porting 'Make the ACS endpoint configurable' to CKAN 2.8 