### PR TITLE
Avoid error on empty request context

### DIFF
--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -131,7 +131,7 @@ def acs():
 
 def get_requested_authn_contexts():
     requested_authn_contexts = config.get('ckanext.saml2auth.requested_authn_context', None)
-    if requested_authn_contexts is None:
+    if requested_authn_contexts is None or requested_authn_contexts == '':
         return []
 
     return requested_authn_contexts.strip().split()


### PR DESCRIPTION
Just for the case when the user accidentally define empty setting `ckanext.saml2auth.requested_authn_context=`
Pysaml2 will raise an error in that cases