### PR TITLE
Improve unique name generation

### DIFF
--- a/ckanext/saml2auth/helpers.py
+++ b/ckanext/saml2auth/helpers.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
 import logging
 import string
+import re
+import random
 import secrets
 from six import text_type
 
@@ -56,3 +58,21 @@ def activate_user_if_deleted(userobj):
         userobj.activate()
         userobj.commit()
         log.info(u'User {} reactivated'.format(userobj.name))
+
+
+def ensure_unique_username_from_email(email):
+    localpart = email.split('@')[0]
+    cleaned_localpart = re.sub(r'[^\w]', '-', localpart).lower()
+
+    if not model.User.get(cleaned_localpart):
+        return cleaned_localpart
+
+    max_name_creation_attempts = 10
+
+    for i in range(max_name_creation_attempts):
+        random_number = random.SystemRandom().random() * 10000
+        name = '%s-%d' % (cleaned_localpart, random_number)
+        if not model.User.get(name):
+            return name
+
+    return cleaned_localpart

--- a/ckanext/saml2auth/tests/test_helpers.py
+++ b/ckanext/saml2auth/tests/test_helpers.py
@@ -81,3 +81,23 @@ def test_activate_user_if_deleted():
     user.delete()
     h.activate_user_if_deleted(user)
     assert not user.is_deleted()
+
+
+@pytest.mark.usefixtures(u'clean_db')
+def test_ensure_unique_user_name_existing_user():
+
+    user = factories.User(
+        name='existing-user',
+        email=u'existing-user@example.com'
+    )
+
+    user_name = h.ensure_unique_username_from_email(user['email'])
+
+    assert user_name != user['email'].split('@')[0]
+    assert user_name.startswith(user['email'].split('@')[0])
+
+
+def test_ensure_unique_user_name_non_existing_user():
+
+    user_name = h.ensure_unique_username_from_email('non-existing-user@example.com')
+    assert user_name == 'non-existing-user'

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -10,7 +10,6 @@ import ckan.logic as logic
 import ckan.lib.dictization.model_dictize as model_dictize
 from ckan.lib import base
 from ckan.views.user import set_repoze_user
-from ckan.logic.action.create import _get_random_username_from_email
 from ckan.common import config, g, request
 
 from ckanext.saml2auth.spconfig import get_config as sp_config
@@ -88,7 +87,7 @@ def process_user(email, saml_id, firstname, lastname):
             base.abort(400, error_message)
 
     data_dict = {
-        u'name': _get_random_username_from_email(email),
+        u'name': h.ensure_unique_username_from_email(email),
         u'fullname': u'{0} {1}'.format(firstname, lastname),
         u'email': email,
         u'password': h.generate_password(),


### PR DESCRIPTION
Only add random digits to the user name if an existing user has the same user name, otherwise use the local part of the email. eg for a user logging in with `jane-doe@example.com` use `jane-doe`, not `jane-doe-5767`)

Move the function to the own extension and add tests.