### PR TITLE
Support fullname field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,10 @@ Required::
      # Corresponding SAML user field for lastname
      ckanext.saml2auth.user_lastname = lastname
 
+     # Corresponding SAML user field for fullname
+     # (Optional: Can be used as an alternative to firstname + lastname)
+     ckanext.saml2auth.user_fullname = fullname
+
      # Corresponding SAML user field for email
      ckanext.saml2auth.user_email = email
 

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -27,9 +27,7 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
         # exception if they're missing.
         missing_config = "{0} is not configured. Please amend your .ini file."
         config_options = (
-            'ckanext.saml2auth.user_firstname',
-            'ckanext.saml2auth.user_lastname',
-            'ckanext.saml2auth.user_email'
+            'ckanext.saml2auth.user_email',
         )
         if not config.get('ckanext.saml2auth.idp_metadata.local_path'):
             config_options += ('ckanext.saml2auth.idp_metadata.remote_url',
@@ -37,6 +35,17 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
         for option in config_options:
             if not config.get(option, None):
                 raise RuntimeError(missing_config.format(option))
+
+        first_and_last_name = all((
+            config.get('ckanext.saml2auth.user_firstname'),
+            config.get('ckanext.saml2auth.user_lastname')
+        ))
+        full_name = config.get('ckanext.saml2auth.user_fullname')
+
+        if not first_and_last_name and not full_name:
+            raise RuntimeError('''
+You need to provide both ckanext.saml2auth.user_firstname +
+ckanext.saml2auth.user_lastname or ckanext.saml2auth.user_fullname'''.strip())
 
         acs_endpoint = config.get('ckanext.saml2auth.acs_endpoint')
         if acs_endpoint and not acs_endpoint.startswith('/'):

--- a/ckanext/saml2auth/tests/responses/unsigned0.xml
+++ b/ckanext/saml2auth/tests/responses/unsigned0.xml
@@ -39,6 +39,15 @@
       <saml:Attribute Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
         <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
       </saml:Attribute>
+      <saml:Attribute Name="firstname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue>John</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="lastname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue>Smith</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="fullname" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue>John Smith (Operations)</saml:AttributeValue>
+      </saml:Attribute>
       <saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
         <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
         <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>

--- a/ckanext/saml2auth/tests/test_blueprint_get_request.py
+++ b/ckanext/saml2auth/tests/test_blueprint_get_request.py
@@ -2,7 +2,6 @@
 import base64
 from datetime import datetime
 from jinja2 import Template
-from nose.tools import assert_equal, assert_in
 import os
 import pytest
 
@@ -38,8 +37,8 @@ class TestGetRequest:
             'SAMLResponse': ''
         }
         response = app.post(url=url, status=400, params=data)
-        assert_equal(400, response.status_code)
-        assert_in(u'Empty login request', response)
+        assert 400 == response.status_code
+        assert u'Empty login request' in response
 
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path', os.path.join(extras_folder, 'provider0', 'idp.xml'))
@@ -53,8 +52,8 @@ class TestGetRequest:
             'SAMLResponse': '<saml>'
         }
         response = app.post(url=url, status=400, params=data)
-        assert_equal(400, response.status_code)
-        assert_in(u'Bad login request', response)
+        assert 400 == response.status_code
+        assert u'Bad login request' in response
 
     def _b4_encode_string(self, message):
         message_bytes = message.encode('ascii')
@@ -89,7 +88,7 @@ class TestGetRequest:
             'SAMLResponse': encoded_response
         }
         response = app.post(url=url, params=data)
-        assert_equal(200, response.status_code)
+        assert 200 == response.status_code
 
     def render_file(self, path, context, save_as=None):
         """ open file and render contect values """
@@ -178,7 +177,7 @@ class TestGetRequest:
             'cert_file': cert_file,
             'encryption_keypairs': [
                 {'key_file': key_file, 'cert_file': cert_file}
-                ]
+            ]
         }
 
     def _generate_cert(self):
@@ -280,7 +279,7 @@ class TestGetRequest:
             'SAMLResponse': encoded_response
         }
         response = app.post(url=url, params=data)
-        assert_equal(200, response.status_code)
+        assert 200 == response.status_code
 
     @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity')
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
@@ -339,7 +338,7 @@ class TestGetRequest:
             'SAMLResponse': encoded_response
         }
         response = app.post(url=url, params=data)
-        assert_equal(200, response.status_code)
+        assert 200 == response.status_code
 
     @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity')
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
@@ -369,7 +368,7 @@ class TestGetRequest:
             'SAMLResponse': encoded_response
         }
         response = app.post(url=url, params=data)
-        assert_equal(200, response.status_code)
+        assert 200 == response.status_code
 
         user = model.User.by_email('test@example.com')[0]
 
@@ -406,7 +405,7 @@ class TestGetRequest:
             'SAMLResponse': encoded_response
         }
         response = app.post(url=url, params=data)
-        assert_equal(200, response.status_code)
+        assert 200 == response.status_code
 
         user = model.User.by_email('test@example.com')[0]
 

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -30,7 +30,7 @@ def _get_requested_authn_contexts():
     return requested_authn_contexts.strip().split()
 
 
-def process_user(email, saml_id, firstname, lastname):
+def process_user(email, saml_id, full_name):
     """ Check if CKAN-SAML user exists for the current SAML login """
 
     context = {
@@ -53,9 +53,9 @@ def process_user(email, saml_id, firstname, lastname):
         # SAML user name or SAML user email are changed
         # in the identity provider
         if email != user_dict['email'] \
-                or u'{0} {1}'.format(firstname, lastname) != user_dict['fullname']:
+                or full_name != user_dict['fullname']:
             user_dict['email'] = email
-            user_dict['fullname'] = u'{0} {1}'.format(firstname, lastname)
+            user_dict['fullname'] = full_name
             try:
                 user_dict = logic.get_action(u'user_update')(context, user_dict)
             except logic.ValidationError as e:
@@ -89,7 +89,7 @@ def process_user(email, saml_id, firstname, lastname):
 
     data_dict = {
         u'name': _get_random_username_from_email(email),
-        u'fullname': u'{0} {1}'.format(firstname, lastname),
+        u'fullname': full_name,
         u'email': email,
         u'password': h.generate_password(),
         u'plugin_extras': {
@@ -118,6 +118,8 @@ def acs():
         config.get(u'ckanext.saml2auth.user_firstname')
     saml_user_lastname = \
         config.get(u'ckanext.saml2auth.user_lastname')
+    saml_user_fullname = \
+        config.get(u'ckanext.saml2auth.user_fullname')
     saml_user_email = \
         config.get(u'ckanext.saml2auth.user_email')
 
@@ -148,10 +150,17 @@ def acs():
     # Required user attributes for user creation
     email = auth_response.ava[saml_user_email][0]
 
-    firstname = auth_response.ava.get(saml_user_firstname, [email.split('@')[0]])[0]
-    lastname = auth_response.ava.get(saml_user_lastname, [email.split('@')[1]])[0]
+    if saml_user_firstname and saml_user_lastname:
+        first_name = auth_response.ava.get(saml_user_firstname, [email.split('@')[0]])[0]
+        last_name = auth_response.ava.get(saml_user_lastname, [email.split('@')[1]])[0]
+        full_name = u'{} {}'.format(first_name, last_name)
+    else:
+        if saml_user_fullname in auth_response.ava:
+            full_name = auth_response.ava[saml_user_fullname][0]
+        else:
+            full_name = u'{} {}'.format(email.split('@')[0], email.split('@')[1])
 
-    g.user = process_user(email, saml_id, firstname, lastname)
+    g.user = process_user(email, saml_id, full_name)
 
     # Check if the authenticated user email is in given list of emails
     # and make that user sysadmin and opposite

--- a/test.ini
+++ b/test.ini
@@ -18,7 +18,7 @@ use = config:../ckan/test-core.ini
 
 ckanext.saml2auth.idp_metadata.location = local
 ckanext.saml2auth.idp_metadata.local_path = /path/to/idp.xml
-ckanext.saml2auth.user_firstname = name
+ckanext.saml2auth.user_firstname = firstname
 ckanext.saml2auth.user_lastname = lastname
 ckanext.saml2auth.user_email = email
 


### PR DESCRIPTION
As discussed in #11 in some cases it is useful to use the "full name" claim rather than the concatenation of "first" + "last" name. Setting aside that not all parts of the world use the first + last name format for people's names, in some projects I'm working on some customization is applied in the IdP side to the user display name, eg to show the department the user belongs to (eg "John Garcia (Operations)").

This change keeps all existing functionality relying on first + last names but adds support for a new config option to provide the full name instead. Startup checks and default fallbacks work in the same way as before.

I included some additional cleanup in the tests, removing a `nose` dependency