### PR TITLE
Support RelayState (redirecting to the user-requested page)

### DIFF
--- a/ckanext/saml2auth/tests/extras/provider2/idp.xml
+++ b/ckanext/saml2auth/tests/extras/provider2/idp.xml
@@ -1,0 +1,45 @@
+<EntityDescriptor
+    ID="_session_ID_1234"
+    xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    entityID="urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity">
+
+    <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor use="signing">
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <X509Data>
+                    <X509Certificate>MIICQTCCAaoCAQEwDQYJKoZIhvcNAQELBQAwaTELMAkGA1UEBhMCc2UxCzAJBgNVBAgMAmFjMQ0wCwYDVQQHDAR1bWVhMRgwFgYDVQQKDA9UZXN0IFVuaXZlcnNpdHkxDTALBgNVBAsMBERlY2ExFTATBgNVBAMMDGxvY2FsaG9zdC5jYTAeFw0yMTAyMTgxMTQ0MTNaFw0yMTAyMTgxMTQ0MTRaMGkxCzAJBgNVBAYTAnNlMQswCQYDVQQIDAJhYzENMAsGA1UEBwwEdW1lYTEYMBYGA1UECgwPVGVzdCBVbml2ZXJzaXR5MQ0wCwYDVQQLDAREZWNhMRUwEwYDVQQDDAxsb2NhbGhvc3QuY2EwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKuoGUe4UbPS0uH2GA0v0L0zvZGf8LdePzRQtmJF2KCnaUEM/oTLQ6TrX7rjyv4qQpgtWpef5UcRgHoIJsjxAnYy+oaAu2/rXlCcVTGgoB2qe6dWMnCmSb2g7vS+DFQHPC5h+q5g+rtyO7HECs8uizpuOuBHCF8X2MkAKsyA7LtLAgMBAAEwDQYJKoZIhvcNAQELBQADgYEAqWwqti53HvC0r9p8q/6FYfZeffLJKxz1koofLhTuA2rhVda9P6tHdjESg/++A2bw+QawEE2SMvl3MIWnEx/izkYQUD4soP0zYtR54TxyhiIIZbaEJkqKCWDwYGZBpHC1HkxRmBR05vtl7yFzLwTqn6UPzK5a1e5CUgnR6837u/I=</X509Certificate>
+                </X509Data>
+            </KeyInfo>
+        </KeyDescriptor>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress</NameIDFormat>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.organization.com/auth"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.organization.com/auth"/>
+    </IDPSSODescriptor>
+    <AttributeAuthorityDescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor use="signing">
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <X509Data>
+                    <X509Certificate>MIICQTCCAaoCAQEwDQYJKoZIhvcNAQELBQAwaTELMAkGA1UEBhMCc2UxCzAJBgNVBAgMAmFjMQ0wCwYDVQQHDAR1bWVhMRgwFgYDVQQKDA9UZXN0IFVuaXZlcnNpdHkxDTALBgNVBAsMBERlY2ExFTATBgNVBAMMDGxvY2FsaG9zdC5jYTAeFw0yMTAyMTgxMTQ0MTNaFw0yMTAyMTgxMTQ0MTRaMGkxCzAJBgNVBAYTAnNlMQswCQYDVQQIDAJhYzENMAsGA1UEBwwEdW1lYTEYMBYGA1UECgwPVGVzdCBVbml2ZXJzaXR5MQ0wCwYDVQQLDAREZWNhMRUwEwYDVQQDDAxsb2NhbGhvc3QuY2EwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKuoGUe4UbPS0uH2GA0v0L0zvZGf8LdePzRQtmJF2KCnaUEM/oTLQ6TrX7rjyv4qQpgtWpef5UcRgHoIJsjxAnYy+oaAu2/rXlCcVTGgoB2qe6dWMnCmSb2g7vS+DFQHPC5h+q5g+rtyO7HECs8uizpuOuBHCF8X2MkAKsyA7LtLAgMBAAEwDQYJKoZIhvcNAQELBQADgYEAqWwqti53HvC0r9p8q/6FYfZeffLJKxz1koofLhTuA2rhVda9P6tHdjESg/++A2bw+QawEE2SMvl3MIWnEx/izkYQUD4soP0zYtR54TxyhiIIZbaEJkqKCWDwYGZBpHC1HkxRmBR05vtl7yFzLwTqn6UPzK5a1e5CUgnR6837u/I=</X509Certificate>
+                </X509Data>
+            </KeyInfo>
+        </KeyDescriptor>
+        <Organization>
+            <OrganizationName xml:lang="en">IDP Organization</OrganizationName>
+            <OrganizationDisplayName xml:lang="en">IDP Organization</OrganizationDisplayName>
+            <OrganizationURL xml:lang="en">https://idp.organization.com</OrganizationURL>
+        </Organization>
+        <ContactPerson contactType="technical"></ContactPerson>
+        <AttributeService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.organization.com/attributes"/>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress</NameIDFormat>
+    </AttributeAuthorityDescriptor>
+    <Organization>
+        <OrganizationName xml:lang="en">IDP Organization</OrganizationName>
+        <OrganizationDisplayName xml:lang="en">IDP Organization</OrganizationDisplayName>
+        <OrganizationURL xml:lang="en">https://idp.organization.com</OrganizationURL>
+    </Organization>
+    <ContactPerson contactType="technical"></ContactPerson>
+</EntityDescriptor>

--- a/ckanext/saml2auth/tests/test_blueprint.py
+++ b/ckanext/saml2auth/tests/test_blueprint.py
@@ -34,7 +34,7 @@ class TestBlueprint(object):
 
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path',
-                             os.path.join(extras_folder, 'provider1', 'idp_cert_template.xml'))
+                             os.path.join(extras_folder, 'provider2', 'idp.xml'))
     def test_came_from_sent_as_relay_state(self, app):
 
         url = url_for('saml2auth.saml2login', came_from='/dataset/my-dataset')

--- a/ckanext/saml2auth/tests/test_blueprint.py
+++ b/ckanext/saml2auth/tests/test_blueprint.py
@@ -34,7 +34,7 @@ class TestBlueprint(object):
 
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path',
-                             os.path.join(extras_folder, 'provider1', 'idp.xml'))
+                             os.path.join(extras_folder, 'provider1', 'idp_cert_template.xml'))
     def test_came_from_sent_as_relay_state(self, app):
 
         url = url_for('saml2auth.saml2login', came_from='/dataset/my-dataset')

--- a/ckanext/saml2auth/tests/test_client.py
+++ b/ckanext/saml2auth/tests/test_client.py
@@ -13,6 +13,7 @@ extras_folder = os.path.join(here, 'extras')
 @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
 @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path',
                          os.path.join(extras_folder, 'provider0', 'idp.xml'))
+@pytest.mark.usefixtures(u'with_request_context')
 def test_empty_comparison():
     with pytest.raises(ValueError) as e:
         saml2login()

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -166,8 +166,14 @@ def acs():
     h.update_user_sysadmin_status(g.user, email)
 
     g.userobj = model.User.by_name(g.user)
+
+    relay_state = request.form.get('RelayState')
+    redirect_target = toolkit.url_for(
+        relay_state, _external=True) if relay_state else u'user.me'
+
+    resp = toolkit.redirect_to(redirect_target)
+
     # log the user in programmatically
-    resp = toolkit.redirect_to(u'user.me')
     set_repoze_user(g.user, resp)
     return resp
 
@@ -178,6 +184,7 @@ def saml2login():
     '''
     client = h.saml_client(sp_config())
     requested_authn_contexts = _get_requested_authn_contexts()
+    relay_state = toolkit.request.args.get('came_from', '')
 
     if len(requested_authn_contexts) > 0:
         comparison = config.get('ckanext.saml2auth.requested_authn_context_comparison',
@@ -191,9 +198,9 @@ def saml2login():
             comparison=comparison
         )
 
-        reqid, info = client.prepare_for_authenticate(requested_authn_context=final_context)
+        reqid, info = client.prepare_for_authenticate(requested_authn_context=final_context, relay_state=relay_state)
     else:
-        reqid, info = client.prepare_for_authenticate()
+        reqid, info = client.prepare_for_authenticate(relay_state=relay_state)
 
     redirect_url = None
     for key, value in info[u'headers']:


### PR DESCRIPTION
This change adds support for redirecting the user to the original page a user requested when they were redirected to the login page (ie same as the `came_from` argument on the native login). This is useful when the user is redirected to the login page after trying to access a restricted one, specially on sites that require logged in users to access any page at all.

In Saml2 this is implemented using the `RelayState` parameter, which is sent by the client to the IdP when requesting the authentication, and returned by the IdP to the ACS alongside the SamlResponse.