### PR TITLE
ISaml2Auth interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,11 +137,11 @@ Optional::
      ckanext.saml2auth.want_response_signed = False
      ckanext.saml2auth.want_assertions_signed = False
      ckanext.saml2auth.want_assertions_or_response_signed = True
-    
+
      # Cert & key files
      ckanext.saml2auth.key_file_path = /path/to/mykey.pem
      ckanext.saml2auth.cert_file_path = /path/to/mycert.pem
-    
+
      # Attribute map directory
      ckanext.saml2auth.attribute_map_dir = /path/to/dir/attributemaps
 
@@ -154,6 +154,20 @@ Optional::
      # Define the comparison value for RequestedAuthnContext
      # Comparison could be one of this: exact, minimum, maximum or better
      ckanext.saml2auth.requested_authn_context_comparison = exact
+
+----------------
+Plugin interface
+----------------
+
+This extension provides the `ISaml2Auth` interface that allows other plugins to hook into the Saml2 authorization flow.
+This allows plugins to integrate custom logic like:
+
+* Include additional attributes returned via the IdP as `plugin_extras` in the CKAN users
+* Assign users to specific organizations with specific roles based on Saml2 attributes
+* Customize the flow response, to eg issue redirects or include custom headers.
+
+For a list of available methods and their parameters check the [`ckanext/saml2auth/interfaces.py`](ckanext/saml2auth/interfaces.py) file, and for a basic example see the [`ExampleISaml2AuthPlugin`](ckanext/saml2auth/tests/test_interface.py) class.
+
 
 ----------------------
 Developer installation

--- a/ckanext/saml2auth/helpers.py
+++ b/ckanext/saml2auth/helpers.py
@@ -54,6 +54,8 @@ def update_user_sysadmin_status(username, email):
 
 def activate_user_if_deleted(userobj):
     u'''Reactivates deleted user.'''
+    if not userobj:
+        return
     if userobj.is_deleted():
         userobj.activate()
         userobj.commit()

--- a/ckanext/saml2auth/interfaces.py
+++ b/ckanext/saml2auth/interfaces.py
@@ -31,9 +31,12 @@ class ISaml2Auth(Interface):
         returning the request. The logged in user can be accessed using g.user
         or g.userobj
 
+        It should always return the provided response object (which can be of course
+        modified)
+
         :param resp: A Flask response object. Can be used to issue
             redirects, add headers, etc
         :param saml_attributes: A dict containing extra SAML attributes returned
             as part of the SAML Response
         '''
-        pass
+        return resp

--- a/ckanext/saml2auth/interfaces.py
+++ b/ckanext/saml2auth/interfaces.py
@@ -1,0 +1,39 @@
+from ckan.plugins.interfaces import Interface
+
+
+class ISaml2Auth(Interface):
+    u'''
+    This interface allows plugins to hook into the Saml2 authorization flow
+    '''
+    def before_saml2_user_update(self, user_dict, saml_attributes):
+        u'''
+        Called just before updating an existing user
+
+        :param user_dict: User metadata dict that will be passed to user_update
+        :param saml_attributes: A dict containing extra SAML attributes returned
+            as part of the SAML Response
+        '''
+        pass
+
+    def before_saml2_user_create(self, user_dict, saml_attributes):
+        u'''
+        Called just before creating a new user
+
+        :param user_dict: User metadata dict that will be passed to user_create
+        :param saml_attributes: A dict containing extra SAML attributes returned
+            as part of the SAML Response
+        '''
+        pass
+
+    def after_saml2_login(self, resp, saml_attributes):
+        u'''
+        Called once the user has been logged in programatically, just before
+        returning the request. The logged in user can be accessed using g.user
+        or g.userobj
+
+        :param resp: A Flask response object. Can be used to issue
+            redirects, add headers, etc
+        :param saml_attributes: A dict containing extra SAML attributes returned
+            as part of the SAML Response
+        '''
+        pass

--- a/ckanext/saml2auth/tests/test_interface.py
+++ b/ckanext/saml2auth/tests/test_interface.py
@@ -1,0 +1,162 @@
+import os
+from collections import defaultdict
+
+import pytest
+
+import ckan.model as model
+import ckan.plugins as plugins
+from ckan.tests import factories
+
+from ckanext.saml2auth.interfaces import ISaml2Auth
+from ckanext.saml2auth.tests.test_blueprint_get_request import (
+    _prepare_unsigned_response
+)
+
+here = os.path.dirname(os.path.abspath(__file__))
+extras_folder = os.path.join(here, 'extras')
+
+
+class ExampleISaml2AuthPlugin(plugins.SingletonPlugin):
+
+    plugins.implements(ISaml2Auth, inherit=True)
+
+    def __init__(self, *args, **kwargs):
+
+        self.calls = defaultdict(int)
+
+    def before_saml2_user_update(self, user_dict, saml_attributes):
+
+        self.calls['before_saml2_user_update'] += 1
+
+        user_dict['fullname'] += ' TEST UPDATE'
+
+        user_dict['plugin_extras']['my_plugin'] = {}
+        user_dict['plugin_extras']['my_plugin']['key1'] = 'value1'
+
+    def before_saml2_user_create(self, user_dict, saml_attributes):
+
+        self.calls['before_saml2_user_create'] += 1
+
+        user_dict['fullname'] += ' TEST CREATE'
+
+        user_dict['plugin_extras']['my_plugin'] = {}
+        user_dict['plugin_extras']['my_plugin']['key2'] = 'value2'
+
+    def after_saml2_login(self, resp, saml_attributes):
+
+        self.calls['after_saml2_login'] += 1
+
+        resp.headers['X-Custom-header'] = 'test'
+
+        return resp
+
+
+@pytest.mark.usefixtures(u'clean_db', u'with_plugins')
+@pytest.mark.ckan_config(u'ckan.plugins', u'saml2auth')
+@pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity')
+@pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
+@pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path', os.path.join(extras_folder, 'provider0', 'idp.xml'))
+@pytest.mark.ckan_config(u'ckanext.saml2auth.want_response_signed', u'False')
+@pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_signed', u'False')
+@pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_or_response_signed', u'False')
+class TestInterface(object):
+
+    def test_after_login_is_called(self, app):
+
+        encoded_response = _prepare_unsigned_response()
+        url = '/acs'
+
+        data = {
+            'SAMLResponse': encoded_response
+        }
+
+        with plugins.use_plugin("test_saml2auth") as plugin:
+            response = app.post(url=url, params=data, follow_redirects=False)
+            assert 302 == response.status_code
+
+            assert plugin.calls["after_saml2_login"] == 1, plugin.calls
+
+            assert response.headers['X-Custom-header'] == 'test'
+
+    def test_before_create_is_called(self, app):
+
+        encoded_response = _prepare_unsigned_response()
+        url = '/acs'
+
+        data = {
+            'SAMLResponse': encoded_response
+        }
+
+        with plugins.use_plugin("test_saml2auth") as plugin:
+            response = app.post(url=url, params=data, follow_redirects=False)
+            assert 302 == response.status_code
+
+            assert plugin.calls["before_saml2_user_create"] == 1, plugin.calls
+
+        user = model.User.by_email('test@example.com')[0]
+
+        assert user.fullname.endswith('TEST CREATE')
+
+        assert user.plugin_extras['my_plugin']['key2'] == 'value2'
+
+        assert 'saml_id' in user.plugin_extras['saml2auth']
+
+    def test_before_update_is_called_on_saml_user(self, app):
+
+        # From unsigned0.xml
+        saml_id = '_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7'
+
+        user = factories.User(
+            email='test@example.com',
+            plugin_extras={
+                'saml2auth': {
+                    'saml_id': saml_id,
+                }
+            }
+        )
+
+        encoded_response = _prepare_unsigned_response()
+        url = '/acs'
+
+        data = {
+            'SAMLResponse': encoded_response
+        }
+
+        with plugins.use_plugin("test_saml2auth") as plugin:
+            response = app.post(url=url, params=data, follow_redirects=False)
+            assert 302 == response.status_code
+
+            assert plugin.calls["before_saml2_user_update"] == 1, plugin.calls
+
+        user = model.User.by_email('test@example.com')[0]
+
+        assert user.fullname.endswith('TEST UPDATE')
+
+        assert user.plugin_extras['my_plugin']['key1'] == 'value1'
+
+        assert user.plugin_extras['saml2auth']['saml_id'] == saml_id
+
+    def test_before_update_is_called_on_ckan_user(self, app):
+
+        user = factories.User(
+            email='test@example.com',
+        )
+
+        encoded_response = _prepare_unsigned_response()
+        url = '/acs'
+
+        data = {
+            'SAMLResponse': encoded_response
+        }
+
+        with plugins.use_plugin("test_saml2auth") as plugin:
+            response = app.post(url=url, params=data, follow_redirects=False)
+            assert 302 == response.status_code
+
+            assert plugin.calls["before_saml2_user_update"] == 1, plugin.calls
+
+        user = model.User.by_email('test@example.com')[0]
+
+        assert user.fullname.endswith('TEST UPDATE')
+
+        assert 'saml_id' in user.plugin_extras['saml2auth']

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,9 @@ setup(
         [ckan.plugins]
         saml2auth=ckanext.saml2auth.plugin:Saml2AuthPlugin
 
+        # Test plugins
+        test_saml2auth=ckanext.saml2auth.tests.test_interface:ExampleISaml2AuthPlugin
+
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan
     ''',


### PR DESCRIPTION
Fixes #13 

This implements the first version of the `ISaml2Auth` interface as discussed in #13, allowing other plugins to hook into the Saml authentication process.

I refactored the `process_user()` method in the blueprint to make it easier to extend, so it's probably best to start with babfa44. The existing default logic remains unchanged for authenticated users:

1. If an existing CKAN user exists with the same `saml_id`, only update it if the email or fullname changed
2. If an existing CKAN user exists with the same email, update the password
3. If a CKAN user does not exist, create a new one

In addition to the above, plugins implementing `ISaml2Auth` can override the logic in points 1 and 2 to suit their needs (eg always updating the user on login).

Happy to answer any questions if there are any. Includes tests and docs