### PR TITLE
Allow to customize the fallback route when no RelayState is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Optional:
     # Default: urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
     ckanext.saml2auth.logout_expected_binding =  urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
 
+    # Default fallback endpoint to redirect to if no RelayState provided in the SAML Response
+    # Default: user.me (ie /dashboard)
+    # e.g. to redirect to the home page
+    ckanext.saml2auth.default_fallback_endpoint = home.index
+
 ## Plugin interface
 
 This extension provides the [ISaml2Auth]{.title-ref} interface that

--- a/ckanext/saml2auth/tests/test_blueprint_get_request.py
+++ b/ckanext/saml2auth/tests/test_blueprint_get_request.py
@@ -428,3 +428,40 @@ class TestGetRequest:
         response = app.post(url=url, params=data, follow_redirects=False)
 
         assert response.headers['Location'] == 'http://test.ckan.net/dataset/my-dataset'
+
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path', os.path.join(extras_folder, 'provider0', 'idp.xml'))
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_response_signed', u'False')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_signed', u'False')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_or_response_signed', u'False')
+    def test_no_relay_state_redirects_to_fallback_default(self, app):
+
+        encoded_response = _prepare_unsigned_response()
+        url = '/acs'
+
+        data = {
+            'SAMLResponse': encoded_response,
+        }
+        response = app.post(url=url, params=data, follow_redirects=False)
+
+        assert response.headers['Location'] == 'http://test.ckan.net/user/me'
+
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path', os.path.join(extras_folder, 'provider0', 'idp.xml'))
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_response_signed', u'False')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_signed', u'False')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_or_response_signed', u'False')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.default_fallback_endpoint', 'dataset.search')
+    def test_no_relay_state_redirects_to_fallback_config(self, app):
+
+        encoded_response = _prepare_unsigned_response()
+        url = '/acs'
+
+        data = {
+            'SAMLResponse': encoded_response,
+        }
+        response = app.post(url=url, params=data, follow_redirects=False)
+
+        assert response.headers['Location'] == 'http://test.ckan.net/dataset/'

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -258,7 +258,8 @@ def acs():
 
     relay_state = request.form.get('RelayState')
     redirect_target = toolkit.url_for(
-        relay_state, _external=True) if relay_state else u'user.me'
+        relay_state, _external=True) if relay_state else config.get(
+            'ckanext.saml2auth.default_fallback_endpoint', 'user.me')
 
     resp = toolkit.redirect_to(redirect_target)
 


### PR DESCRIPTION
If the SAMLResponse doesn't contain a RelayState parameter (a previous page that we want to redirect the user to) right now the plugin redirects to the user dashboard (the `user.me` route).

This change keeps this default behaviour but allows to customize the route in case fallback redirection to another page is required.