### PR TITLE
[#55] Clear cookies on logout

### DIFF
--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -140,10 +140,22 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                         extra_vars = {
                             u'body': body
                         }
-                        return base.render(u'saml2auth/idp_logout.html', extra_vars)
+                        response = base.render(u'saml2auth/idp_logout.html', extra_vars)
+
                     elif binding == entity.BINDING_HTTP_REDIRECT:
                         log.debug(
                             'Redirecting to the IdP to continue the logout process')
-                        return redirect(h.get_location(http_info), code=302)
+
+                        response = redirect(h.get_location(http_info), code=302)
                     else:
                         log.error('Failed to log out from Idp. Unknown binding: {}'.format(binding))
+
+            domain = h.get_site_domain()
+
+            # Clear auth cookie in the browser
+            response.set_cookie('auth_tkt', domain=domain, expires=0)
+
+            # Clear session cookie in the browser
+            response.set_cookie('ckan', domain=domain, expires=0)
+
+            return response

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -21,7 +21,7 @@ import logging
 from saml2.client_base import LogoutError
 from saml2 import entity
 
-from flask import session, redirect
+from flask import session, redirect, make_response
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
@@ -159,7 +159,9 @@ def _perform_slo():
                 extra_vars = {
                     u'body': body
                 }
-                response = base.render(u'saml2auth/idp_logout.html', extra_vars)
+                response = make_response(
+                    base.render(u'saml2auth/idp_logout.html', extra_vars)
+                )
 
             elif binding == entity.BINDING_HTTP_REDIRECT:
                 log.debug(


### PR DESCRIPTION
Fixes #55 

As it is currently implemented, SLO correctly logs the user out from the IdP, but leaves the local CKAN user logged in in the CKAN site. This is because the auth and session cookies (`auth_tkt` and `ckan`) are not cleared like in a normal logout. This effectively leaves the user logged in, with all the security implications this has.

*Note*: I have only access to IdP that use an HTTP-Redirect SLO binding, so I haven't been able to test it with a POST binding. I believe that the same issue exist and the proposed logic also solves the issue but it would be great if someone with could test it with a POST binding.

This change modifies the response returned by the `IAuthenticator.logout()` hook to include the necessary headers to clear
both cookies. The main change is in 7800a38. The rest of the changes are a refactoring to make easier to add a test.
