### PR TITLE
Inherit all IAuthenticator methods

### DIFF
--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -42,7 +42,7 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.ITemplateHelpers)
-    plugins.implements(plugins.IAuthenticator)
+    plugins.implements(plugins.IAuthenticator, inherit=True)
 
     # ITemplateHelpers
 
@@ -94,12 +94,6 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
         toolkit.add_resource('fanstatic', 'saml2auth')
 
     # IAuthenticator
-
-    def identify(self):
-        pass
-
-    def login(self):
-        pass
 
     def logout(self):
 


### PR DESCRIPTION
Otherwise when using the plugins and one of the not implemented methods
is called we get an exception instead of the actual error:

```
  File "/usr/lib/python3.8/site-packages/flask/views.py", line 163, in dispatch_request
    return meth(*args, **kwargs)
  File "/srv/app/src_extensions/ckan/ckan/views/dataset.py", line 740, in post
    return base.abort(403, _(u'Unauthorized to read package %s') % id)
  File "/srv/app/src_extensions/ckan/ckan/lib/base.py", line 59, in abort
    result = item.abort(status_code, detail, headers, comment)
AttributeError: 'Saml2AuthPlugin' object has no attribute 'abort'
```