### PR TITLE
Replace copyright HTML comments with Jinja2 ones

### DIFF
--- a/ckanext/saml2auth/templates/header.html
+++ b/ckanext/saml2auth/templates/header.html
@@ -1,4 +1,4 @@
-<!--
+{#
 Copyright (c) 2020 Keitaro AB
 
 This program is free software: you can redistribute it and/or modify
@@ -13,7 +13,7 @@ GNU Affero General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+#}
 
 {% ckan_extends %}
 {% block header_account_notlogged %}

--- a/ckanext/saml2auth/templates/user/snippets/login_form.html
+++ b/ckanext/saml2auth/templates/user/snippets/login_form.html
@@ -1,4 +1,4 @@
-<!--
+{#
 Copyright (c) 2020 Keitaro AB
 
 This program is free software: you can redistribute it and/or modify
@@ -13,7 +13,7 @@ GNU Affero General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
--->
+#}
 
 {% ckan_extends %}
 {% block login_button %}


### PR DESCRIPTION
Otherwise the "Copyright (c) 2020 Keitaro AB" notice appears at the top of the source code of every page on any site using ckanext-saml2auth, and while the copyright applies to the contents of these templates, it does not to the rest of the site source code.