### PR TITLE
added exception type for UnsupportedBinding from SLO.

### DIFF
--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -32,7 +32,7 @@ from ckanext.saml2auth.views.saml2auth import saml2auth
 from ckanext.saml2auth.cache import get_subject_id, get_saml_session_info
 from ckanext.saml2auth.spconfig import get_config as sp_config
 from ckanext.saml2auth import helpers as h
-
+from saml2.s_utils import UnsupportedBinding
 
 log = logging.getLogger(__name__)
 
@@ -129,10 +129,11 @@ def _perform_slo():
     try:
         client.users.add_information_about_person(saml_session_info)
         result = client.global_logout(name_id=subject_id)
-    except LogoutError as e:
+    except (LogoutError, UnsupportedBinding) as e:
         log.exception(
             'SLO not supported by IDP: {}'.format(e))
         # clear session
+        return
 
     if not result:
         log.error(


### PR DESCRIPTION
This PR is to fix the logout issue without SLO, please see detail in https://github.com/GSA/data.gov/issues/3708

Solved two problems in the PR:
1. Got 'internal server error' when logout without SLO. Found the code where reports the error,  and the UnsupportedBinding error was not in the exception list :
    saml2.s_utils.UnsupportedBinding: None
    So added the UnsupportedBinding to the exception list to catch for unsupported SLO. 

2. Also, after catch any exception from SLO, the process continued, so added the 'return'  after catching the exception in order to not continue the process with unknown 'result' variable. 

