### PR TITLE
Fix broken login in CKAN>=2.9.6

### DIFF
--- a/ckanext/saml2auth/tests/test_blueprint_get_request.py
+++ b/ckanext/saml2auth/tests/test_blueprint_get_request.py
@@ -22,8 +22,13 @@ from datetime import datetime
 from jinja2 import Template
 import os
 import pytest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from ckan import model
+from ckan.plugins import toolkit
 
 from saml2.xmldsig import SIG_RSA_SHA256
 from saml2.xmldsig import DIGEST_SHA256
@@ -465,3 +470,32 @@ class TestGetRequest:
         response = app.post(url=url, params=data, follow_redirects=False)
 
         assert response.headers['Location'] == 'http://test.ckan.net/dataset/'
+
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.entity_id', u'urn:gov:gsa:SAML:2.0.profiles:sp:sso:test:entity')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path', os.path.join(extras_folder, 'provider0', 'idp.xml'))
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_response_signed', u'False')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_signed', u'False')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_or_response_signed', u'False')
+    def test_repoze_user_id(self, app):
+
+        encoded_response = _prepare_unsigned_response()
+        url = '/acs'
+
+        data = {
+            'SAMLResponse': encoded_response
+        }
+
+        with mock.patch("ckanext.saml2auth.views.saml2auth.set_repoze_user") as m:
+            app.post(url=url, params=data)
+
+            user = model.User.by_email('test@example.com')[0]
+
+            assert m.called
+            # Check login worked fine by checking the Response object
+            assert m.call_args[0][1].headers["Location"].endswith("/user/me")
+
+            if toolkit.check_ckan_version(min_version="2.9.6"):
+                assert m.call_args[0][0] == user.id + ",1"
+            else:
+                assert m.call_args[0][0] == user.name

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -264,7 +264,12 @@ def acs():
     resp = toolkit.redirect_to(redirect_target)
 
     # log the user in programmatically
-    set_repoze_user(g.user, resp)
+    if toolkit.check_ckan_version(min_version="2.9.6"):
+        user_id = "{},1".format(g.userobj.id)
+    else:
+        user_id = g.userobj.name
+    # TODO: This won't work on CKAN 2.10
+    set_repoze_user(user_id, resp)
     set_saml_session_info(session, session_info)
     set_subject_id(session, session_info['name_id'])
 


### PR DESCRIPTION
CKAN 2.9.6 introduced a security change in the way Repoze auth cookies are set up. Previously, the user identifier stored in the cookie was the user name, but that has been changed to the user internal id plus a serial auto-increment (currently static).
As ckanext-saml2auth calls the `set_repoze_user` directly we need to update what gets passed to be stored in the cookie, otherwise the user will never be logged in.
Previous versions should keep using the user name to avoid the same problem.

Note that all this will no longer be relevant on CKAN 2.10 as it uses a completely different login system.