### PR TITLE
Enable Python 3.9 tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8' ]
+        python-version: [ '3.7', '3.8', '3.9']
     name: Python ${{ matrix.python-version }} extension test
 
     services:


### PR DESCRIPTION
With the latest patch release CKAN 2.9 should run fine in Python 3.9 so it's worth testing it in this version