### PR TITLE
Bump Github action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
   code_quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -69,10 +69,10 @@ jobs:
           - 8983:8983
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -102,10 +102,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 


### PR DESCRIPTION
I am a member of the data.gov team (which uses this repo) and [have been updating](https://github.com/GSA/data.gov/issues/4005) the GitHub action versions used in our own repos as many have been updated and some deprecated. I noticed that the actions used here are also deprecated, specifically:
- [`actions/checkout`](https://github.com/marketplace/actions/checkout) is now on `v3`
- [`actions/setup-python`](https://github.com/marketplace/actions/setup-python) is now at `v4`

This isn't blocking our work, this would affect your action runs. Just wanted to be a good neighborhood!