### PR TITLE
CKAN 2.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches: main
 
-env:
-  CKANVERSION: 2.9
-      
 jobs:
   code_quality:
     runs-on: ubuntu-latest
@@ -36,6 +33,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9']
+        ckan-version: ["2.9", "2.10"]
     name: Python ${{ matrix.python-version }} extension test
 
     services:
@@ -86,6 +84,7 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
+          export CKANVERSION=${{matrix.ckan-version}}
           bash bin/setup-ckan.bash
 
       - name: Test with pytest

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -101,12 +101,12 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
 
         if response:
             domain = h.get_site_domain_for_cookie()
-
-            # Clear auth cookie in the browser
-            response.set_cookie('auth_tkt', domain=domain, expires=0)
-
             # Clear session cookie in the browser
             response.set_cookie('ckan', domain=domain, expires=0)
+
+            if not toolkit.check_ckan_version(min_version="2.10"):
+                # CKAN <= 2.9.x also sets auth_tkt cookie
+                response.set_cookie('auth_tkt', domain=domain, expires=0)
 
         return response
 

--- a/ckanext/saml2auth/tests/test_blueprint.py
+++ b/ckanext/saml2auth/tests/test_blueprint.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
 import pytest
 
+from ckan.plugins import toolkit
 from ckan.plugins.toolkit import url_for
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -64,9 +65,10 @@ class TestBlueprint(object):
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path',
                              os.path.join(extras_folder, 'provider2', 'idp.xml'))
     @pytest.mark.usefixtures('with_request_context')
-    @pytest.mark.skip
     def test_cookies_cleared_on_slo(self, app):
-
+        if toolkit.check_ckan_version(min_version='2.10'):
+            # Remove when dropping support for 2.9
+            pytest.skip("auth_tkt cookie has been deprecated in 2.10")
         url = url_for('user.logout')
 
         import datetime
@@ -94,3 +96,43 @@ class TestBlueprint(object):
             assert cookie[cookie_name]['domain'] == 'test.ckan.net'
             cookie_date = date_parse(cookie[cookie_name]['expires'], ignoretz=True)
             assert cookie_date < datetime.datetime.now()
+
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.location', u'local')
+    @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path',
+                             os.path.join(extras_folder, 'provider2', 'idp.xml'))
+    @pytest.mark.usefixtures('with_request_context')
+    def test_ckan_cookie_cleared_on_slo(self, app):
+        if not toolkit.check_ckan_version(min_version='2.10'):
+            # Remove when dropping support for 2.9
+            pytest.skip("This test logic introduced in CKAN 2.10")
+        url = url_for('user.logout')
+
+        import datetime
+        from unittest import mock
+        from http.cookies import SimpleCookie
+        from flask import make_response
+        from dateutil.parser import parse as date_parse
+
+        with mock.patch(
+            'ckanext.saml2auth.plugin._perform_slo',
+                return_value=make_response('')):
+            response = app.get(url=url, follow_redirects=False)
+
+        cookie_headers = [
+            h[1] for h in response.headers
+            if h[0].lower() == 'set-cookie']
+
+        # Starting 2.10, CKAN's SessionMiddleware will append a
+        # new Set-cookie header on every first response from the server.
+        # This includes test requests.
+        assert len(cookie_headers) == 2
+
+        first_cookie = cookie_headers[0]
+
+        cookie = SimpleCookie()
+        cookie.load(first_cookie)
+        cookie_name = [name for name in cookie.keys()][0]
+        assert cookie_name == 'ckan'
+        assert cookie[cookie_name]['domain'] == 'test.ckan.net'
+        cookie_date = date_parse(cookie[cookie_name]['expires'], ignoretz=True)
+        assert cookie_date < datetime.datetime.now()

--- a/ckanext/saml2auth/tests/test_blueprint.py
+++ b/ckanext/saml2auth/tests/test_blueprint.py
@@ -64,6 +64,7 @@ class TestBlueprint(object):
     @pytest.mark.ckan_config(u'ckanext.saml2auth.idp_metadata.local_path',
                              os.path.join(extras_folder, 'provider2', 'idp.xml'))
     @pytest.mark.usefixtures('with_request_context')
+    @pytest.mark.skip
     def test_cookies_cleared_on_slo(self, app):
 
         url = url_for('user.logout')

--- a/ckanext/saml2auth/tests/test_blueprint_get_request.py
+++ b/ckanext/saml2auth/tests/test_blueprint_get_request.py
@@ -387,7 +387,9 @@ class TestGetRequest:
         response = app.post(url=url, params=data)
         assert 200 == response.status_code
 
-        user = model.User.by_email('test@example.com')[0]
+        user = model.User.by_email('test@example.com')
+        if isinstance(user, list):
+            user = user[0]
 
         assert user.fullname == 'John Smith'
 
@@ -411,7 +413,9 @@ class TestGetRequest:
         response = app.post(url=url, params=data)
         assert 200 == response.status_code
 
-        user = model.User.by_email('test@example.com')[0]
+        user = model.User.by_email('test@example.com')
+        if isinstance(user, list):
+            user = user[0]
 
         assert user.fullname == 'John Smith (Operations)'
 
@@ -478,7 +482,9 @@ class TestGetRequest:
     @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_signed', u'False')
     @pytest.mark.ckan_config(u'ckanext.saml2auth.want_assertions_or_response_signed', u'False')
     def test_repoze_user_id(self, app):
-
+        if not toolkit.check_ckan_version(max_version='2.9.6'):
+            # Remove when dropping support for 2.9.6
+            pytest.skip("set_repoze_user has been deprecated in 2.10")
         encoded_response = _prepare_unsigned_response()
         url = '/acs'
 
@@ -489,7 +495,9 @@ class TestGetRequest:
         with mock.patch("ckanext.saml2auth.views.saml2auth.set_repoze_user") as m:
             app.post(url=url, params=data)
 
-            user = model.User.by_email('test@example.com')[0]
+            user = model.User.by_email('test@example.com')
+            if isinstance(user, list):
+                user = user[0]
 
             assert m.called
             # Check login worked fine by checking the Response object

--- a/ckanext/saml2auth/tests/test_interface.py
+++ b/ckanext/saml2auth/tests/test_interface.py
@@ -110,7 +110,9 @@ class TestInterface(object):
 
             assert plugin.calls["before_saml2_user_create"] == 1, plugin.calls
 
-        user = model.User.by_email('test@example.com')[0]
+        user = model.User.by_email('test@example.com')
+        if isinstance(user, list):
+            user = user[0]
 
         assert user.fullname.endswith('TEST CREATE')
 
@@ -145,7 +147,9 @@ class TestInterface(object):
 
             assert plugin.calls["before_saml2_user_update"] == 1, plugin.calls
 
-        user = model.User.by_email('test@example.com')[0]
+        user = model.User.by_email('test@example.com')
+        if isinstance(user, list):
+            user = user[0]
 
         assert user.fullname.endswith('TEST UPDATE')
 
@@ -172,7 +176,9 @@ class TestInterface(object):
 
             assert plugin.calls["before_saml2_user_update"] == 1, plugin.calls
 
-        user = model.User.by_email('test@example.com')[0]
+        user = model.User.by_email('test@example.com')
+        if isinstance(user, list):
+            user = user[0]
 
         assert user.fullname.endswith('TEST UPDATE')
 

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -276,7 +276,7 @@ def acs():
 def _log_user_into_ckan(resp):
     """ Log the user into different CKAN versions.
 
-    CKAN 2.10 introduces flask-login and it changes the login system.
+    CKAN 2.10 introduces flask-login and login_user method.
 
     CKAN 2.9.6 added a security change and identifies the user
     with the internal id plus a serial autoincrement (currently static).

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -77,7 +77,7 @@ def _get_user_by_saml_id(saml_id):
 def _get_user_by_email(email):
 
     user = model.User.by_email(email)
-    if isinstance(user, list):
+    if user and isinstance(user, list):
         user = user[0]
 
     h.activate_user_if_deleted(user)

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -76,13 +76,13 @@ def _get_user_by_saml_id(saml_id):
 
 def _get_user_by_email(email):
 
-    user_obj = model.User.by_email(email)
-    if user_obj:
-        user_obj = user_obj[0]
+    user = model.User.by_email(email)
+    if isinstance(user, list):
+        user = user[0]
 
-    h.activate_user_if_deleted(user_obj)
+    h.activate_user_if_deleted(user)
 
-    return _dictize_user(user_obj) if user_obj else None
+    return _dictize_user(user) if user else None
 
 
 def _update_user(user_dict):
@@ -263,13 +263,8 @@ def acs():
 
     resp = toolkit.redirect_to(redirect_target)
 
-    # log the user in programmatically
-    if toolkit.check_ckan_version(min_version="2.9.6"):
-        user_id = "{},1".format(g.userobj.id)
-    else:
-        user_id = g.userobj.name
-    # TODO: This won't work on CKAN 2.10
-    set_repoze_user(user_id, resp)
+    _log_user_into_ckan(resp)
+
     set_saml_session_info(session, session_info)
     set_subject_id(session, session_info['name_id'])
 
@@ -277,6 +272,27 @@ def acs():
         resp = plugin.after_saml2_login(resp, auth_response.ava)
 
     return resp
+
+def _log_user_into_ckan(resp):
+    """ Log the user into different CKAN versions.
+
+    CKAN 2.10 introduces flask-login and it changes the login system.
+
+    CKAN 2.9.6 added a security change and identifies the user
+    with the internal id plus a serial autoincrement (currently static).
+
+    CKAN <= 2.9.5 identifies the user only using the internal id.
+    """
+    if toolkit.check_ckan_version(min_version="2.10"):
+        from ckan.common import login_user
+        login_user(g.userobj)
+        return
+
+    if toolkit.check_ckan_version(min_version="2.9.6"):
+        user_id = "{},1".format(g.userobj.id)
+    else:
+        user_id = g.userobj.name
+    set_repoze_user(user_id, resp)
 
 
 def saml2login():


### PR DESCRIPTION
Hello!

This is a PR to add support for CKAN 2.10. I will be doing a migration of a huge instace of CKAN to `2.10` using `ckanext-saml2auth` in the upcoming weeks/months so I will be heavily testing this PR.

## CKAN 2.10 changes affecting ckanext-saml2auth
 - `User.by_email(...)` now returns an object (instead of a list)
 - Repoze has been replaced for `flask-login` and this includes several changes:
   -  Login is now handled by `user_login` function (instead of `set_repoze_user`)
   - `auth_tkt` cookie has been deprecated since it was being set by Repoze 

## Notes on Cookie Behaviour

This is possible a discussion for CKAN core but I will document it here since to give context to the PR changes.

On 2.9, CKAN appends `ckan` and `auth_tkt` `Set-Cookie` headers after successfully login.

On  2.10, CKAN appends a `Set-cookie` header to the first response issued by the server as a part of our `SessionMiddleware` [provided by beaker](https://github.com/bbangert/beaker/blob/de94aefa7cb132fc2614be9c6c08a048737004a0/beaker/middleware.py#L148-L155). This affects also `app.get(...)` tests methods. 

![Screenshot from 2022-12-12 12-36-00](https://user-images.githubusercontent.com/6672339/207280838-8d0580a9-3937-4ac1-941a-4e6e448a6010.png)


Given this I'm struggling on how to test that our `ckan` cookie gets clear on SLO since the **test request** returns two cookies:

```python
# headers from our SLO response
ipdb> cookie_headers
['ckan=; Domain=test.ckan.net; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/', ' ckan=320c96f267a65ee3d2c2cae8b3e45ce2cb86b5b4bce4f66b296d49568a976e93aacd0827; Path=/; SameSite=Lax']
```
