### PR TITLE
Audit authentication events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.7', '3.8', '3.9']
         ckan-version: ["2.9", "2.10"]

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -108,7 +108,10 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 # CKAN <= 2.9.x also sets auth_tkt cookie
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
-        log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
+        if g.userobj is not None:
+            log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
+        else:
+            log.info("No user was logged in!")
 
         return response
 

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -108,12 +108,7 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 # CKAN <= 2.9.x also sets auth_tkt cookie
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
-        if toolkit.check_ckan_version(min_version="2.10"):
-            empty_user = ""
-        else:
-            empty_user = None
-
-        if g.userobj is not empty_user:
+        if g.userobj:
             log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
         else:
             log.info("No user was logged in!")

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -108,7 +108,7 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 # CKAN <= 2.9.x also sets auth_tkt cookie
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
-        log.info("Logout successful %s" % (g.userobj.name))
+        log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
 
         return response
 

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -109,9 +109,9 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
         if g.userobj:
-            log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
+            log.info(u'User {0}<{1}> logged out successfully'.format(g.userobj.name, g.userobj.email))
         else:
-            log.info("No user was logged in!")
+            log.info(u'No user was logged in!')
 
         return response
 

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -108,7 +108,7 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 # CKAN <= 2.9.x also sets auth_tkt cookie
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
-            log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
+        log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
 
         return response
 

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -108,7 +108,7 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 # CKAN <= 2.9.x also sets auth_tkt cookie
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
-        log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
+            log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
 
         return response
 

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -108,6 +108,8 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 # CKAN <= 2.9.x also sets auth_tkt cookie
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
+        log.info("Logout successful %s" % (g.userobj.name))
+
         return response
 
 

--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -108,7 +108,12 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
                 # CKAN <= 2.9.x also sets auth_tkt cookie
                 response.set_cookie('auth_tkt', domain=domain, expires=0)
 
-        if g.userobj is not None:
+        if toolkit.check_ckan_version(min_version="2.10"):
+            empty_user = ""
+        else:
+            empty_user = None
+
+        if g.userobj is not empty_user:
             log.info("Logout successful %s<%s>" % (g.userobj.name, g.userobj.email))
         else:
             log.info("No user was logged in!")

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -295,6 +295,8 @@ def _log_user_into_ckan(resp):
         user_id = g.userobj.name
     set_repoze_user(user_id, resp)
 
+    log.info("Login successful %s" % (g.userobj.name))
+
 
 def saml2login():
     u'''Redirects the user to the

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -295,7 +295,7 @@ def _log_user_into_ckan(resp):
         user_id = g.userobj.name
     set_repoze_user(user_id, resp)
 
-    log.info("Login successful %s<%s>" % (g.userobj.name, g.userobj.email))
+    log.info(u'User {0}<{1}> logged in successfully'.format(g.userobj.name, g.userobj.email))
 
 
 def saml2login():

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -295,7 +295,7 @@ def _log_user_into_ckan(resp):
         user_id = g.userobj.name
     set_repoze_user(user_id, resp)
 
-    log.info("Login successful %s" % (g.userobj.name))
+    log.info("Login successful %s<%s>" % (g.userobj.name, g.userobj.email))
 
 
 def saml2login():


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/2867

Hi fellow CKAN developers!  

This PR is coming from the Data.gov team to meet compliance requirements.  In order to capture information related to user login/logout, two log statements are added:
- After the SAML Handshake is complete and the `_log_user_into_ckan` function is called, it logs which user has entered the system.
- After the SLO Handshake is complete within the `logout` function, it logs when the ckan auth cookie is invalidated.

Other notable changes:
- Allow all Github Action tests to run even if one fails with `fail-fast: false`