### PR TITLE
pysqml2 7.4 requires python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     namespace_packages=['ckanext'],
 
-    install_requires=['pysaml2>=6.5.1'],
+    install_requires=['pysaml2>=6.5.1,<7.4'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
Check https://github.com/IdentityPython/pysaml2/releases/tag/v7.4.0

Error I saw:

```
from ckanext.saml2auth.client import Saml2Client
  File "/__w/ckanext-unhcr/ckanext-unhcr/ckanext-saml2auth/ckanext/saml2auth/client.py", line 19, in <module>
    from saml2.client import Saml2Client
  File "/usr/lib/python3.8/site-packages/pysaml2-7.4.0-py3.8.egg/saml2/__init__.py", line 432, in <module>
    class SamlBase(ExtensionContainer):
  File "/usr/lib/python3.8/site-packages/pysaml2-7.4.0-py3.8.egg/saml2/__init__.py", line 442, in SamlBase
    c_child_order: list[str] = []
TypeError: 'type' object is not subscriptable
```