### PR TITLE
 add config create_user_via_saml, default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Optional:
     ckanext.saml2auth.enable_ckan_internal_login = True
 
     # Indicates if CKAN should auto create a user for a new SAML login
-    # Note that if set False, a new user must be manually created in CKAN before they can log in using SAML
+    # If set False, a new user must be manually created in CKAN before they can log in using SAML
+    # If set False, existing user must be in active state to able to log in.
     # Default: True
     ckanext.saml2auth.create_user_via_saml = True
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Optional:
     # Default: False
     ckanext.saml2auth.enable_ckan_internal_login = True
 
+    # Indicates if CKAN should auto create a user for a new SAML login
+    # Note that if set False, a new user must be manually created in CKAN before they can log in using SAML
+    # Default: True
+    ckanext.saml2auth.create_user_via_saml = True
+
     # List of email addresses from users that should be created as sysadmins (system administrators)
     # Note that this means that CKAN sysadmins will _only_ be managed based on this config option and will override existing user permissions in the CKAN database
     # If not set then it is ignored and CKAN sysadmins are managed through normal means

--- a/ckanext/saml2auth/helpers.py
+++ b/ckanext/saml2auth/helpers.py
@@ -50,6 +50,12 @@ def generate_password():
     return password
 
 
+def is_create_user_via_saml_enabled():
+    return toolkit.asbool(
+        toolkit.config.get('ckanext.saml2auth.create_user_via_saml', True)
+    )
+
+
 def is_default_login_enabled():
     return toolkit.asbool(
         toolkit.config.get('ckanext.saml2auth.enable_ckan_internal_login')

--- a/ckanext/saml2auth/tests/test_helpers.py
+++ b/ckanext/saml2auth/tests/test_helpers.py
@@ -42,6 +42,15 @@ def test_default_login_enabled():
     assert h.is_default_login_enabled()
 
 
+def test_create_user_via_saml_disabled_by_default():
+    assert not h.is_create_user_via_saml_enabled()
+
+
+@pytest.mark.ckan_config(u'ckanext.saml2auth.create_user_via_saml', True)
+def test_create_user_via_saml_enabled():
+    assert h.is_create_user_via_saml_enabled()
+
+
 @pytest.mark.usefixtures(u'clean_db', u'clean_index')
 @pytest.mark.ckan_config(u'ckanext.saml2auth.sysadmins_list', '')
 def test_00_update_user_sysadmin_status_continue_as_regular():


### PR DESCRIPTION
This PR adds a new config `ckanext.saml2auth.create_user_via_saml`.  Default value is `True`.

Setting it `False` means not all users from IdP can log in to the CKAN. A user with same email must already exist and be active before the user can log in via SAML. 
