### PR TITLE
logging the login information from both API and saml.

### DIFF
--- a/ckanext/saml2auth/plugin.py
+++ b/ckanext/saml2auth/plugin.py
@@ -25,7 +25,7 @@ from flask import session, redirect, make_response
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
-from ckan.common import g
+from ckan.common import g, current_user
 import ckan.lib.base as base
 
 from ckanext.saml2auth.views.saml2auth import saml2auth
@@ -94,6 +94,13 @@ class Saml2AuthPlugin(plugins.SingletonPlugin):
         toolkit.add_resource('fanstatic', 'saml2auth')
 
     # IAuthenticator
+
+    def identify(self):
+            if current_user.is_authenticated and current_user.is_active and not session.get('last_active'):
+                log.info('User {0}<{1}> logged in successfully{2}.'.format(
+                    current_user.name, current_user.email,
+                    ' via saml' if session.get('_saml_session_info') else ''
+                ))
 
     def logout(self):
 

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -295,8 +295,6 @@ def _log_user_into_ckan(resp):
         user_id = g.userobj.name
     set_repoze_user(user_id, resp)
 
-    log.info(u'User {0}<{1}> logged in successfully'.format(g.userobj.name, g.userobj.email))
-
 
 def saml2login():
     u'''Redirects the user to the


### PR DESCRIPTION
This PR [extends identify() in IAuthenticator](https://github.com/ckan/ckan/blob/master/ckan/plugins/interfaces.py#L1671)

We log user login  information from both API and saml calls. and removed the log just for saml login. 
