### PR TITLE
User to organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ Optional:
     # e.g. to redirect to the home page
     ckanext.saml2auth.default_fallback_endpoint = home.index
 
+    # If specified, the new users registered on the portal will be put in this organization.
+    # You can specify the organization name here or leave it blank.
+    # When left blank (the default), the new users are not added to any organization.
+    ckanext.saml2auth.user_default_org=
+    # The default role for the new users in the specified organization.
+    # This is not activated unless ckanext.saml2auth.user_default_org is set.
+    # The possible values are: member, editor or admin - the role for the user when
+    # added in the organization.
+    # If unset, the user would get a role of 'member' in the organization.
+    ckanext.saml2auth.user_default_role=
+
 ## Plugin interface
 
 This extension provides the [ISaml2Auth]{.title-ref} interface that

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -378,7 +378,7 @@ saml2auth.add_url_rule(acs_endpoint, view_func=acs, methods=[u'GET', u'POST'])
 saml2auth.add_url_rule(u'/user/saml2login', view_func=saml2login)
 if not h.is_default_login_enabled():
     saml2auth.add_url_rule(
-        u'/user/login', view_func=disable_default_login_register)
+        u'/user/login', view_func=disable_default_login_register, methods=[u'GET', u'POST'])
     saml2auth.add_url_rule(
-        u'/user/register', view_func=disable_default_login_register)
+        u'/user/register', view_func=disable_default_login_register, methods=[u'GET', u'POST'])
 saml2auth.add_url_rule(u'/slo', view_func=slo, methods=[u'GET', u'POST'])

--- a/ckanext/saml2auth/views/saml2auth.py
+++ b/ckanext/saml2auth/views/saml2auth.py
@@ -375,7 +375,7 @@ def slo():
 
 acs_endpoint = config.get('ckanext.saml2auth.acs_endpoint', '/acs')
 saml2auth.add_url_rule(acs_endpoint, view_func=acs, methods=[u'GET', u'POST'])
-saml2auth.add_url_rule(u'/user/saml2login', view_func=saml2login)
+saml2auth.add_url_rule(u'/user/saml2login', view_func=saml2login, methods=[u'GET', u'POST'])
 if not h.is_default_login_enabled():
     saml2auth.add_url_rule(
         u'/user/login', view_func=disable_default_login_register, methods=[u'GET', u'POST'])


### PR DESCRIPTION
Fixes the default landing page route and adds option to add the new users from SSO provider to a default organization.