### PR TITLE
Include ckan root_path when building consumer service endpoint

### DIFF
--- a/ckanext/saml2auth/spconfig.py
+++ b/ckanext/saml2auth/spconfig.py
@@ -29,7 +29,9 @@ def get_config():
         Read: https://pysaml2.readthedocs.io/en/latest/howto/config.html
         """
 
-    base = ckan_config.get('ckan.site_url')
+    # include the root_path in url construction
+    base = ckan_config.get('ckan.site_url') + (ckan_config.get('ckan.root_path') or '')
+
     debug = asbool(ckan_config.get('debug'))
     allow_unknown_attributes = \
         ckan_config.get(u'ckanext.saml2auth.allow_unknown_attributes', True)

--- a/ckanext/saml2auth/tests/test_spconfig.py
+++ b/ckanext/saml2auth/tests/test_spconfig.py
@@ -96,6 +96,13 @@ def test_read_acs_endpoint():
     acs_endpoint = get_config()[u'service'][u'sp'][u'endpoints'][u'assertion_consumer_service'][0]
     assert acs_endpoint.endswith('/my/acs/endpoint')
 
+@pytest.mark.ckan_config(u'ckanext.saml2auth.acs_endpoint', u'/my/acs/endpoint')
+@pytest.mark.ckan_config(u'ckan.root_path', u'/customrootpath')
+def test_read_acs_endpoint_with_root_path():
+
+    acs_endpoint = get_config()[u'service'][u'sp'][u'endpoints'][u'assertion_consumer_service'][0]
+    assert acs_endpoint.endswith('/customrootpath/my/acs/endpoint')
+
 
 @pytest.mark.ckan_config(u'ckanext.saml2auth.requested_authn_context', u'req1')
 def test_one_requested_authn_context():


### PR DESCRIPTION
**The problem:**
When using the root_path option in ckan.ini, the url given to the IDP did not include that part. This way the IDP could not redirect to the ACS after login, if ckan was running on another path than "/".

In our setup we have a nginx-reverse-proxy that filters the root_path (requests "/root_path/something" get redirected to ckan server as "/something") and the root_path is defined as "/root_path" in ckan.ini (in this example).

We first tried to modify `ckanext.saml2auth.acs_endpoint` and set it to "/root_path/acs", but that messed up the add_url_rule routes for the acs view.

**The solution:**
We just added root_path to the url given to the IDP. This way spconfig will inform the IDP of the correct url to access ckan, just like ckan itself uses root_path to build external urls.
